### PR TITLE
Do not overwrite formId in every ModalFormResponsePacket

### DIFF
--- a/src/Infernus101/KitUI/Main.php
+++ b/src/Infernus101/KitUI/Main.php
@@ -24,6 +24,7 @@ class Main extends PluginBase implements Listener {
   public $kitused = [];
   public $language;
   public $piggyEnchants;
+  public $config;
 	
     public function onEnable(){
       @mkdir($this->getDataFolder()."timer/");

--- a/src/Infernus101/KitUI/PlayerEvents.php
+++ b/src/Infernus101/KitUI/PlayerEvents.php
@@ -68,11 +68,11 @@ class PlayerEvents implements Listener {
 				return;
 			}
 			$windowHandler = new Handler();
-			$packet->formId = $windowHandler->getWindowIdFor($packet->formId);
-			if(!$windowHandler->isInRange($packet->formId)) {
+			$formId = $windowHandler->getWindowIdFor($packet->formId);
+			if(!$windowHandler->isInRange($formId)) {
 				return;
 			}
-			$window = $windowHandler->getWindow($packet->formId, $this->pl, $event->getPlayer());
+			$window = $windowHandler->getWindow($formId, $this->pl, $event->getPlayer());
 			$window->handle($packet);
 		}
 	}


### PR DESCRIPTION
Overwriting `formId` in every ModalFormResponsePacket received prevents other plugins from working correctly. Also added missing `config` class variable.