### PR TITLE
Added events for KitUI

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -2,7 +2,7 @@ name: KitUI
 author: Infernus101
 api: [3.4.0]
 main: Infernus101\KitUI\Main
-version: 1.3.4
+version: 1.3.5
 permissions: # kit permissions - kit.<kit name>
  kit.command:
   description: kit command!

--- a/src/Infernus101/KitUI/Kit.php
+++ b/src/Infernus101/KitUI/Kit.php
@@ -2,174 +2,175 @@
 
 namespace Infernus101\KitUI;
 
+use onebone\economyapi\EconomyAPI;
+use PiggyCustomEnchants\CustomEnchants\CustomEnchants;
 use pocketmine\command\ConsoleCommandSender;
 use pocketmine\entity\Effect;
 use pocketmine\entity\EffectInstance;
 use pocketmine\item\enchantment\Enchantment;
 use pocketmine\item\enchantment\EnchantmentInstance;
 use pocketmine\item\Item;
-use pocketmine\utils\TextFormat;
 use pocketmine\Player;
-use onebone\economyapi\EconomyAPI;
-use DaPigGuy\PiggyCustomEnchants\CustomEnchants\CustomEnchants;
-use pocketmine\Server;
 
-class Kit{
+class Kit {
 
-    public $pl;
-    public $data;
-    public $name;
-    public $cost = 0;
-    public $timer;
-    public $timers = [];
-    public $id = [];
+	public $pl;
+	public $data;
+	public $name;
+	public $cost = 0;
+	public $timer;
+	public $timers = [];
+	public $id = [];
 
-    public function __construct(Main $pl, array $data, string $name){
-        $this->pl = $pl;
-        $this->data = $data;
-        $this->name = $name;
-        $this->timer = $this->getTimerMinutes();
-		if(file_exists($this->pl->getDataFolder()."timer/".strtolower($this->name).".sl")){
-            $this->timers = unserialize(file_get_contents($this->pl->getDataFolder()."timer/".strtolower($this->name).".sl"));
-        }
-        if(isset($this->data["money"]) and $this->data["money"] != 0){
-            $this->cost = (int) $this->data["money"];
-        }
-	if(!isset($this->data["permission"])){
-            $this->data["permission"] = "kit." . $this->name;
-        }
-    }
+	public function __construct(Main $pl, array $data, string $name){
+		$this->pl = $pl;
+		$this->data = $data;
+		$this->name = $name;
+		$this->timer = $this->getTimerMinutes();
+		if(file_exists($this->pl->getDataFolder() . "timer/" . strtolower($this->name) . ".sl")){
+			$this->timers = unserialize(file_get_contents($this->pl->getDataFolder() . "timer/" . strtolower($this->name) . ".sl"));
+		}
+		if(isset($this->data["money"]) and $this->data["money"] != 0){
+			$this->cost = (int)$this->data["money"];
+		}
+		if(!isset($this->data["permission"])){
+			$this->data["permission"] = "kit." . $this->name;
+		}
+	}
 
-    public function getName() : string{
-        return $this->name;
-    }
+	public function getTimerMinutes(): int{
+		$min = 0;
+		if(isset($this->data["cooldown"]["minutes"])){
+			$min += (int)$this->data["cooldown"]["minutes"];
+		}
+		if(isset($this->data["cooldown"]["hours"])){
+			$min += (int)$this->data["cooldown"]["hours"] * 60;
+		}
 
-    public function add(Player $player){
-        $inv = $player->getInventory();
-	$arm = $player->getArmorInventory();
+		return $min;
+	}
 
-        if($this->pl->config->get("clear-effect")){
-            $player->removeAllEffects();
-        }
-		
+	public function getName(): string{
+		return $this->name;
+	}
+
+	public function add(Player $player){
+		$inv = $player->getInventory();
+		$arm = $player->getArmorInventory();
+
+		if($this->pl->config->get("clear-effect")){
+			$player->removeAllEffects();
+		}
+
 		if($this->pl->config->get("clear-inventory")){
 			$inv->clearAll();
 			$player->getCraftingGrid()->clearAll();
 		}
-		
+
 		if(!$this->pl->config->get("start-from-first")){
 			if(count($this->data["items"]) + count($inv->getContents()) > $inv->getSize()){
 				$player->sendMessage($this->pl->language->getTranslation("inv-full"));
+
 				return;
 			}
 			foreach($this->data["items"] as $itemString){
 				$inv->setItem($inv->firstEmpty(), $i = $this->loadItem(...explode(":", $itemString)));
 			}
-		}
-		else{
+		}else{
 			$tag = 0;
 			foreach($this->data["items"] as $itemString){
 				$inv->setItem($tag++, $i = $this->loadItem(...explode(":", $itemString)));
 			}
 		}
-		
-	isset($this->data["helmet"]) and $arm->setHelmet($this->loadItem(...explode(":", $this->data["helmet"])));
-        isset($this->data["chestplate"]) and $arm->setChestplate($this->loadItem(...explode(":", $this->data["chestplate"])));
-        isset($this->data["leggings"]) and $arm->setLeggings($this->loadItem(...explode(":", $this->data["leggings"])));
-        isset($this->data["boots"]) and $arm->setBoots($this->loadItem(...explode(":", $this->data["boots"])));
-	$arm->sendContents($player);
 
-        if(isset($this->data["effects"])){
-            foreach($this->data["effects"] as $effectString){
-                $e = $this->loadEffect(...explode(":", $effectString));
-                if($e !== null){
-                    $player->addEffect($e);
-                }
-            }
-        }
+		isset($this->data["helmet"]) and $arm->setHelmet($this->loadItem(...explode(":", $this->data["helmet"])));
+		isset($this->data["chestplate"]) and $arm->setChestplate($this->loadItem(...explode(":", $this->data["chestplate"])));
+		isset($this->data["leggings"]) and $arm->setLeggings($this->loadItem(...explode(":", $this->data["leggings"])));
+		isset($this->data["boots"]) and $arm->setBoots($this->loadItem(...explode(":", $this->data["boots"])));
+		$arm->sendContents($player);
 
-        if(isset($this->data["commands"]) and is_array($this->data["commands"])){
-            foreach($this->data["commands"] as $cmd){
-                $this->pl->getServer()->dispatchCommand(new ConsoleCommandSender(), str_replace("{player}", $player->getName(), $cmd));
-            }
-        }
-	if(!$player->hasPermission("kit.freepass")){
-	    if($this->timer){
-                $this->timers[strtolower($player->getName())] = $this->timer;
-	    }
+		if(isset($this->data["effects"])){
+			foreach($this->data["effects"] as $effectString){
+				$e = $this->loadEffect(...explode(":", $effectString));
+				if($e !== null){
+					$player->addEffect($e);
+				}
+			}
+		}
+
+		if(isset($this->data["commands"]) and is_array($this->data["commands"])){
+			foreach($this->data["commands"] as $cmd){
+				$this->pl->getServer()->dispatchCommand(new ConsoleCommandSender(), str_replace("{player}", $player->getName(), $cmd));
+			}
+		}
+		if(!$player->hasPermission("kit.freepass")){
+			if($this->timer){
+				$this->timers[strtolower($player->getName())] = $this->timer;
+			}
+		}
+		if(isset($this->data["money"])){
+			EconomyAPI::getInstance()->reduceMoney($player, $this->data["money"]);
+		}
+		$this->pl->kitUsed[strtolower($player->getName())] = $this;
+
 	}
-    	if(isset($this->data["money"])){
-	    EconomyAPI::getInstance()->reduceMoney($player, $this->data["money"]);
+
+	public function loadItem(int $id = 0, int $damage = 0, int $count = 1, string $name = "default", ...$enchantments): Item{
+		$item = Item::get($id, $damage, $count);
+		if(strtolower($name) !== "default"){
+			$item->setCustomName($name);
+		}
+		$enchantment = null;
+		foreach($enchantments as $key => $name_level){
+			if($key % 2 === 0){ //Name expected
+				$enchantment = Enchantment::getEnchantmentByName((string)$name_level);
+				if($enchantment === null){
+					$enchantment = CustomEnchants::getEnchantmentByName((string)$name_level);
+				}
+			}elseif($enchantment !== null){
+				if($this->pl->piggyEnchants !== null && $enchantment instanceof CustomEnchants){
+					$this->pl->piggyEnchants->addEnchantment($item, $enchantment->getName(), (int)$name_level);
+				}else{
+					$item->addEnchantment(new EnchantmentInstance($enchantment, (int)$name_level));
+				}
+			}
+		}
+
+		return $item;
 	}
-        $this->pl->kitused[strtolower($player->getName())] = $this;
 
-    }
+	public function loadEffect(string $name = "INVALID", int $seconds = 60, int $amplifier = 1){
+		return new EffectInstance(Effect::getEffectByName($name), $seconds * 20, $amplifier);
+	}
 
-    public function loadItem(int $id = 0, int $damage = 0, int $count = 1, string $name = "default", ...$enchantments) : Item{
-        $item = Item::get($id, $damage, $count);
-        if(strtolower($name) !== "default"){
-            $item->setCustomName($name);
-        }
-	$ench = null;
-        foreach($enchantments as $key => $name_level){
-            if($key % 2 === 0){ //Name expected
-                $ench = Enchantment::getEnchantmentByName((string) $name_level);
-                if($ench === null){
-                    $ench = CustomEnchants::getEnchantmentByName((string) $name_level);
-                }
-            }elseif($ench !== null){
-                if($this->pl->piggyEnchants !== null && $ench instanceof CustomEnchants){
-                    $this->pl->piggyEnchants->addEnchantment($item, $ench->getName(), (int) $name_level);
-                }else{
-                    $item->addEnchantment(new EnchantmentInstance($ench, (int) $name_level));
-                }
-            }
-        }
-        return $item;
-    }
+	public function getTimerLeft(Player $player): string{
+		if(($minutes = $this->timers[strtolower($player->getName())]) < 60){
+			return $this->pl->language->getTranslation("timer-format1", $minutes);
+		}
+		if(($modulo = $minutes % 60) !== 0){
+			return $this->pl->language->getTranslation("timer-format2", floor($minutes / 60), $modulo);
+		}
 
-    public function loadEffect(string $name = "INVALID", int $seconds = 60, int $amplifier = 1){
-        return new EffectInstance(Effect::getEffectByName($name), $seconds * 20, $amplifier);
-    }
+		return $this->pl->language->getTranslation("timer-format3", $minutes / 60);
+	}
 
-    public function getTimerMinutes() : int{
-        $min = 0;
-        if(isset($this->data["cooldown"]["minutes"])){
-            $min += (int) $this->data["cooldown"]["minutes"];
-        }
-        if(isset($this->data["cooldown"]["hours"])){
-            $min += (int) $this->data["cooldown"]["hours"] * 60;
-        }
-        return $min;
-    }
+	public function processTimer(){
+		foreach($this->timers as $player => $min){
+			$this->timers[$player] -= 1;
+			if($this->timers[$player] <= 0){
+				unset($this->timers[$player]);
+			}
+		}
+	}
 
-    public function getTimerLeft(Player $player) : string{
-        if(($minutes = $this->timers[strtolower($player->getName())]) < 60){
-            return $this->pl->language->getTranslation("timer-format1", $minutes);
-        }
-        if(($modulo = $minutes % 60) !== 0){
-            return $this->pl->language->getTranslation("timer-format2", floor($minutes / 60), $modulo);
-        }
-        return $this->pl->language->getTranslation("timer-format3", $minutes / 60);
-    }
+	public function testPermission(Player $player): bool{
+		return $player->hasPermission($this->data["permission"]);
+	}
 
-    public function processTimer(){
-        foreach($this->timers as $player => $min){
-            $this->timers[$player] -= 1;
-            if($this->timers[$player] <= 0){
-                unset($this->timers[$player]);
-            }
-        }
-    }
-
-    public function testPermission(Player $player) : bool{
-        return $player->hasPermission($this->data["permission"]);
-    }
-
-    public function save(){
-        if(count($this->timers) > 0){
-            file_put_contents($this->pl->getDataFolder()."timer/".strtolower($this->name).".sl", serialize($this->timers));
-        }
-    }
+	public function save(){
+		if(count($this->timers) > 0){
+			file_put_contents($this->pl->getDataFolder() . "timer/" . strtolower($this->name) . ".sl", serialize($this->timers));
+		}
+	}
 
 }

--- a/src/Infernus101/KitUI/Main.php
+++ b/src/Infernus101/KitUI/Main.php
@@ -2,121 +2,133 @@
 
 namespace Infernus101\KitUI;
 
-use Infernus101\KitUI\UI\Handler;
 use Infernus101\KitUI\lang\LangManager;
 use Infernus101\KitUI\tasks\CoolDownTask;
-use pocketmine\Player;
-use pocketmine\Server;
-use pocketmine\command\CommandSender;
-use pocketmine\command\ConsoleCommandSender;
+use Infernus101\KitUI\UI\Handler;
 use pocketmine\command\Command;
+use pocketmine\command\CommandSender;
 use pocketmine\event\Listener;
-use pocketmine\plugin\PluginBase;
 use pocketmine\network\mcpe\protocol\ModalFormRequestPacket;
+use pocketmine\Player;
+use pocketmine\plugin\PluginBase;
 use pocketmine\utils\Config;
 use pocketmine\utils\TextFormat;
-use PiggyCustomEnchants;
 
 class Main extends PluginBase implements Listener {
-	
-  public $kits = [];
-  public $kitused = [];
-  public $language;
-  public $piggyEnchants;
-  public $config;
-	
-    public function onEnable(){
-      @mkdir($this->getDataFolder()."timer/");
-      $this->getServer()->getLogger()->notice("[KitUI] Enabled! - By Infernus101");
-      $this->configFixer();
-      $files = array("kits.yml","config.yml");
-      foreach($files as $file){
-      if(!file_exists($this->getDataFolder() . $file)){
-      @mkdir($this->getDataFolder());
-      file_put_contents($this->getDataFolder() . $file, $this->getResource($file));
-      }
-      }
-      $this->kit = new Config($this->getDataFolder() . "kits.yml", Config::YAML);
-      $this->config = new Config($this->getDataFolder() . "config.yml", Config::YAML);
-      $this->language = new LangManager($this);
-      $this->getServer()->getPluginManager()->registerEvents(new PlayerEvents($this), $this);
-      $this->getScheduler()->scheduleDelayedRepeatingTask(new CoolDownTask($this), 1200, 1200);
-      $this->piggyEnchants = $this->getServer()->getPluginManager()->getPlugin("PiggyCustomEnchants");
-	if($this->piggyEnchants !== null){
-            $this->getServer()->getLogger()->info(TextFormat::GREEN . "[KitUI] Using PiggyCustomEnchants!");
-        }
-      $allKits = yaml_parse_file($this->getDataFolder()."kits.yml");
-      foreach($allKits as $name => $data){
-        $this->kits[$name] = new Kit($this, $data, $name);
-      }
-    }
-	
-    public function onDisable(){
-      foreach($this->kits as $kit){
-        $kit->save();
-      }
-      $this->getServer()->getLogger()->notice("[KitUI] Disabled! - By Infernus101");
-    }
-	
+
+	/** @var Kit[] */
+	public $kits = [];
+	/** @var Kit[] */
+	public $kitUsed = [];
+	/** @var LangManager */
+	public $language;
+	/** @var \PiggyCustomEnchants\Main */
+	public $piggyEnchants;
+	/** @var Config */
+	public $config;
+	/** @var string[][] */
+	public $formData;
+	/** @var Config */
+	private $kit;
+
+	public function onEnable(){
+		@mkdir($this->getDataFolder() . "timer/");
+		$this->getServer()->getLogger()->notice("[KitUI] Enabled! - By Infernus101");
+		$this->configFixer();
+		$files = ["kits.yml", "config.yml"];
+		foreach($files as $file){
+			if(!file_exists($this->getDataFolder() . $file)){
+				@mkdir($this->getDataFolder());
+				file_put_contents($this->getDataFolder() . $file, $this->getResource($file));
+			}
+		}
+		$this->kit = new Config($this->getDataFolder() . "kits.yml", Config::YAML);
+		$this->config = new Config($this->getDataFolder() . "config.yml", Config::YAML);
+		$this->language = new LangManager($this);
+		$this->getServer()->getPluginManager()->registerEvents(new PlayerEvents($this), $this);
+		$this->getScheduler()->scheduleDelayedRepeatingTask(new CoolDownTask($this), 1200, 1200);
+		$this->piggyEnchants = $this->getServer()->getPluginManager()->getPlugin("PiggyCustomEnchants");
+		if($this->piggyEnchants !== null){
+			$this->getServer()->getLogger()->info(TextFormat::GREEN . "[KitUI] Using PiggyCustomEnchants!");
+		}
+		$allKits = yaml_parse_file($this->getDataFolder() . "kits.yml");
+		foreach($allKits as $name => $data){
+			$this->kits[$name] = new Kit($this, $data, $name);
+		}
+	}
+
+	private function configFixer(){
+		$this->saveResource("kits.yml");
+		$allKits = yaml_parse_file($this->getDataFolder() . "kits.yml");
+		$this->fixConfig($allKits);
+		foreach($allKits as $name => $data){
+			$this->kits[$name] = new Kit($this, $data, $name);
+		}
+	}
+
+	private function fixConfig(&$config){
+		foreach($config as $name => $kit){
+			if(isset($kit["users"])){
+				$users = array_map("strtolower", $kit["users"]);
+				$config[$name]["users"] = $users;
+			}
+			if(isset($kit["worlds"])){
+				$worlds = array_map("strtolower", $kit["worlds"]);
+				$config[$name]["worlds"] = $worlds;
+			}
+		}
+	}
+
+	public function onDisable(){
+		foreach($this->kits as $kit){
+			$kit->save();
+		}
+		$this->getServer()->getLogger()->notice("[KitUI] Disabled! - By Infernus101");
+	}
+
 	public function onCommand(CommandSender $sender, Command $cmd, String $label, array $args): bool{
-	  if(!$sender instanceof Player){
-		  $sender->sendMessage(TextFormat::RED."> Command must be run ingame!");
-		  return true;
-	  }
-	  switch(strtolower($cmd->getName())){
-            case "kit":
-			if(!$sender->hasPermission("kit.command")){
-				$sender->sendMessage(TextFormat::RED."> You don't have permission to use this command!");
-				return false;
-			}
-			if(isset($args[0])){
-				$sender->sendMessage(TextFormat::GREEN."About:\nKit UI by Infernus101! github.com/Infernus101/KitUI\n".TextFormat::AQUA."Servers - FallenTech.tk | CounterTech.tk 19132");
-				return false;
-			}
-                $handler = new Handler();
+		if(!$sender instanceof Player){
+			$sender->sendMessage(TextFormat::RED . "> Command must be run ingame!");
+
+			return true;
+		}
+		switch(strtolower($cmd->getName())){
+			case "kit":
+				if(!$sender->hasPermission("kit.command")){
+					$sender->sendMessage(TextFormat::RED . "> You don't have permission to use this command!");
+
+					return false;
+				}
+				if(isset($args[0])){
+					$sender->sendMessage(TextFormat::GREEN . "About:\nKit UI by Infernus101! github.com/Infernus101/KitUI\n" . TextFormat::AQUA . "Servers - FallenTech.tk | CounterTech.tk 19132");
+
+					return false;
+				}
+				$handler = new Handler();
 				$packet = new ModalFormRequestPacket();
 				$packet->formId = $handler->getWindowIdFor(Handler::KIT_MAIN_MENU);
 				$packet->formData = $handler->getWindowJson(Handler::KIT_MAIN_MENU, $this, $sender);
 				$sender->dataPacket($packet);
-            break;
-      }
-        return true;
+				break;
+		}
+
+		return true;
 	}
-	
-    private function configFixer(){
-          $this->saveResource("kits.yml");
-          $allKits = yaml_parse_file($this->getDataFolder()."kits.yml");
-          $this->fixConfig($allKits);
-          foreach($allKits as $name => $data){
-              $this->kits[$name] = new Kit($this, $data, $name);
-          }
-      }
 
-    private function fixConfig(&$config){
-          foreach($config as $name => $kit){
-              if(isset($kit["users"])){
-                  $users = array_map("strtolower", $kit["users"]);
-                  $config[$name]["users"] = $users;
-              }
-              if(isset($kit["worlds"])){
-                  $worlds = array_map("strtolower", $kit["worlds"]);
-                  $config[$name]["worlds"] = $worlds;
-              }
-          }
-      }
+	public function getPlayerKit($player, $obj = false){
+		if($player instanceof Player){
+			$player = $player->getName();
+		}
 
-    public function getPlayerKit($player, $obj = false){
-          if($player instanceof Player){
-        $player = $player->getName();
-      }
-          return isset($this->kitused[strtolower($player)]) ? ($obj ? $this->kitused[strtolower($player)] : $this->kitused[strtolower($player)]->getName()) : null;
-      }
+		return isset($this->kitUsed[strtolower($player)]) ? ($obj ? $this->kitUsed[strtolower($player)] : $this->kitUsed[strtolower($player)]->getName()) : null;
+	}
 
-      public function getKit(string $kit){
-          $lower = array_change_key_case($this->kits, CASE_LOWER);
-          if(isset($lower[strtolower($kit)])){
-              return $lower[strtolower($kit)];
-          }
-          return null;
-      }
- }
+	public function getKit(string $kit): ?Kit{
+		$lower = array_change_key_case($this->kits, CASE_LOWER);
+		if(isset($lower[strtolower($kit)])){
+			return $lower[strtolower($kit)];
+		}
+
+		return null;
+	}
+}

--- a/src/Infernus101/KitUI/PlayerEvents.php
+++ b/src/Infernus101/KitUI/PlayerEvents.php
@@ -2,78 +2,78 @@
 
 namespace Infernus101\KitUI;
 
+use Infernus101\KitUI\UI\Handler;
 use pocketmine\block\Block;
 use pocketmine\event\block\SignChangeEvent;
 use pocketmine\event\Listener;
-use pocketmine\utils\Config;
-use pocketmine\utils\TextFormat;
-use pocketmine\event\server\DataPacketReceiveEvent;
 use pocketmine\event\player\PlayerDeathEvent;
 use pocketmine\event\player\PlayerInteractEvent;
 use pocketmine\event\player\PlayerQuitEvent;
+use pocketmine\event\server\DataPacketReceiveEvent;
 use pocketmine\network\mcpe\protocol\ModalFormRequestPacket;
 use pocketmine\network\mcpe\protocol\ModalFormResponsePacket;
-use pocketmine\Player;
 use pocketmine\tile\Sign;
-use Infernus101\KitUI\UI\Handler;
+use pocketmine\utils\TextFormat;
 
 class PlayerEvents implements Listener {
-	
+
+	/** @var Main */
 	public $pl;
-	
-	public function __construct(Main $pg) {
+
+	public function __construct(Main $pg){
 		$this->pl = $pg;
 	}
-	
-	public function onTap(PlayerInteractEvent $event){
-        $id = $event->getBlock()->getId();
-        if($id === Block::SIGN_POST or $id === Block::WALL_SIGN){
-            $tile = $event->getPlayer()->getLevel()->getTile($event->getBlock());
-            if($tile instanceof Sign){
-                $text = $tile->getText();
-                if(strtolower(TextFormat::clean($text[0])) === strtolower($this->pl->config->get("text-on-sign"))){
-			$event->setCancelled();
-			$handler = new Handler();
-			$packet = new ModalFormRequestPacket();
-			$packet->formId = $handler->getWindowIdFor(Handler::KIT_MAIN_MENU);
-			$packet->formData = $handler->getWindowJson(Handler::KIT_MAIN_MENU, $this->pl, $event->getPlayer());
-			$event->getPlayer()->dataPacket($packet);
-                }
-            }
-        }
-    }
-    public function onSignChange(SignChangeEvent $event){
-        if(strtolower(TextFormat::clean($event->getLine(0))) === strtolower($this->pl->config->get("text-on-sign")) and !$event->getPlayer()->hasPermission("kitui.sign")){
-            $event->getPlayer()->sendMessage($this->pl->language->getTranslation("no-sign-perm"));
-            $event->setCancelled();
-        }
-    }
-	
-    public function onDeath(PlayerDeathEvent $event){
-        if(isset($this->pl->kitused[strtolower($event->getEntity()->getName())])){
-            unset($this->pl->kitused[strtolower($event->getEntity()->getName())]);
-        }
-    }
 
-    public function onLogOut(PlayerQuitEvent $event){
-        if($this->pl->config->get("reset-on-logout") and isset($this->pl->kitused[strtolower($event->getPlayer()->getName())])){
-            unset($this->pl->kitused[strtolower($event->getPlayer()->getName())]);
-        }
-	if(isset($this->pl->id[strtolower($event->getPlayer()->getName())])) unset($this->pl->id[strtolower($event->getPlayer()->getName())]);
-    }
-	
+	public function onTap(PlayerInteractEvent $event){
+		$id = $event->getBlock()->getId();
+		if($id === Block::SIGN_POST or $id === Block::WALL_SIGN){
+			$tile = $event->getPlayer()->getLevel()->getTile($event->getBlock());
+			if($tile instanceof Sign){
+				$text = $tile->getText();
+				if(strtolower(TextFormat::clean($text[0])) === strtolower($this->pl->config->get("text-on-sign"))){
+					$event->setCancelled();
+					$handler = new Handler();
+					$packet = new ModalFormRequestPacket();
+					$packet->formId = $handler->getWindowIdFor(Handler::KIT_MAIN_MENU);
+					$packet->formData = $handler->getWindowJson(Handler::KIT_MAIN_MENU, $this->pl, $event->getPlayer());
+					$event->getPlayer()->dataPacket($packet);
+				}
+			}
+		}
+	}
+
+	public function onSignChange(SignChangeEvent $event){
+		if(strtolower(TextFormat::clean($event->getLine(0))) === strtolower($this->pl->config->get("text-on-sign")) and !$event->getPlayer()->hasPermission("kitui.sign")){
+			$event->getPlayer()->sendMessage($this->pl->language->getTranslation("no-sign-perm"));
+			$event->setCancelled();
+		}
+	}
+
+	public function onDeath(PlayerDeathEvent $event){
+		if(isset($this->pl->kitUsed[strtolower($event->getEntity()->getName())])){
+			unset($this->pl->kitUsed[strtolower($event->getEntity()->getName())]);
+		}
+	}
+
+	public function onLogOut(PlayerQuitEvent $event){
+		if($this->pl->config->get("reset-on-logout") and isset($this->pl->kitUsed[strtolower($event->getPlayer()->getName())])){
+			unset($this->pl->kitUsed[strtolower($event->getPlayer()->getName())]);
+		}
+		if(isset($this->pl->formData[strtolower($event->getPlayer()->getName())])) unset($this->pl->formData[strtolower($event->getPlayer()->getName())]);
+	}
+
 	public function onDataPacket(DataPacketReceiveEvent $event){
 		$packet = $event->getPacket();
-		if($packet instanceof ModalFormResponsePacket) {
+		if($packet instanceof ModalFormResponsePacket){
 			$windowHandler = new Handler();
 			$formId = $windowHandler->getWindowIdFor($packet->formId);
-			if(!$windowHandler->isInRange($formId)) {
+			if(!$windowHandler->isInRange($formId)){
 				return;
 			}
-			if(json_decode($packet->formData, true) === null) {
+			if(json_decode($packet->formData, true) === null){
 				return;
 			}
-			if(!isset($this->pl->id[strtolower($event->getPlayer()->getName())])){
+			if(!isset($this->pl->formData[strtolower($event->getPlayer()->getName())])){
 				return;
 			}
 			$window = $windowHandler->getWindow($formId, $this->pl, $event->getPlayer());

--- a/src/Infernus101/KitUI/UI/Handler.php
+++ b/src/Infernus101/KitUI/UI/Handler.php
@@ -3,9 +3,9 @@
 namespace Infernus101\KitUI\UI;
 
 use Infernus101\KitUI\Main;
-use Infernus101\KitUI\UI\windows\KitMainMenu;
-use Infernus101\KitUI\UI\windows\KitInfo;
 use Infernus101\KitUI\UI\windows\KitError;
+use Infernus101\KitUI\UI\windows\KitInfo;
+use Infernus101\KitUI\UI\windows\KitMainMenu;
 use pocketmine\Player;
 
 class Handler {
@@ -17,31 +17,34 @@ class Handler {
 	private $types = [
 		KitMainMenu::class,
 		KitInfo::class,
-		KitError::class
+		KitError::class,
 	];
 
-	public function getWindowJson(int $windowId, Main $loader, Player $player): string {
+	public function getWindowJson(int $windowId, Main $loader, Player $player): string{
 		return $this->getWindow($windowId, $loader, $player)->getJson();
 	}
 
-	public function getWindow(int $windowId, Main $loader, Player $player): Window {
-		if(!isset($this->types[$windowId])) {
+	public function getWindow(int $windowId, Main $loader, Player $player): Window{
+		if(!isset($this->types[$windowId])){
 			throw new \OutOfBoundsException("Tried to get window of non-existing window ID.");
 		}
+
 		return new $this->types[$windowId]($loader, $player);
 	}
 
-	public function isInRange(int $windowId): bool {
-		if(isset($this->types[$windowId]) || isset($this->types[$windowId + 3200])) {
+	public function isInRange(int $windowId): bool{
+		if(isset($this->types[$windowId]) || isset($this->types[$windowId + 3200])){
 			return true;
 		}
+
 		return false;
 	}
 
-	public function getWindowIdFor(int $windowId): int {
-		if($windowId >= 10100) {
+	public function getWindowIdFor(int $windowId): int{
+		if($windowId >= 10100){
 			return $windowId - 10100;
 		}
+
 		return 10100 + $windowId;
 	}
 }

--- a/src/Infernus101/KitUI/UI/Window.php
+++ b/src/Infernus101/KitUI/UI/Window.php
@@ -9,41 +9,44 @@ use pocketmine\Player;
 
 abstract class Window {
 
+	/** @var int[] */
+	public static $id = [];
+	/** @var Main */
 	protected $pl;
+	/** @var Player */
 	protected $player;
-	public static $id = array();
-	
+	/** @var object[] */
 	protected $data = [];
 
-	public function __construct(Main $pl, Player $player) {
+	public function __construct(Main $pl, Player $player){
 		$this->pl = $pl;
 		$this->player = $player;
-		if(!isset($pl->id[strtolower($player->getName())])){
-			$pl->id[strtolower($player->getName())] = [];
+		if(!isset($pl->formData[strtolower($player->getName())])){
+			$pl->formData[strtolower($player->getName())] = [];
 		}
 		$this->process();
 	}
 
-	public function getJson(): string {
+	protected abstract function process(): void;
+
+	public function getJson(): string{
 		return json_encode($this->data);
 	}
 
-	public function getLoader(): Loader {
+	public function getLoader(): Main{
 		return $this->pl;
 	}
 
-	public function getPlayer(): Player {
+	public function getPlayer(): Player{
 		return $this->player;
 	}
-	
-	public function navigate(int $menu, Player $player, Handler $windowHandler): void {
+
+	public function navigate(int $menu, Player $player, Handler $windowHandler): void{
 		$packet = new ModalFormRequestPacket();
 		$packet->formId = $windowHandler->getWindowIdFor($menu);
 		$packet->formData = $windowHandler->getWindowJson($menu, $this->pl, $player);
 		$player->dataPacket($packet);
 	}
-
-	protected abstract function process(): void;
 
 	public abstract function handle(ModalFormResponsePacket $packet): bool;
 }

--- a/src/Infernus101/KitUI/UI/windows/KitError.php
+++ b/src/Infernus101/KitUI/UI/windows/KitError.php
@@ -2,45 +2,42 @@
 
 namespace Infernus101\KitUI\UI\windows;
 
-use Infernus101\KitUI\Main;
 use Infernus101\KitUI\UI\Handler;
 use Infernus101\KitUI\UI\Window;
-use pocketmine\utils\TextFormat;
-use pocketmine\network\mcpe\protocol\ModalFormRequestPacket;
 use pocketmine\network\mcpe\protocol\ModalFormResponsePacket;
-use pocketmine\Player;
 
 class KitError extends Window {
-	public function process(): void {
-		if(isset($this->pl->id[strtolower($this->player->getName())]["error"])){
-			$error = $this->pl->id[strtolower($this->player->getName())]["error"];
-		}
-		else{
+	public function process(): void{
+		if(isset($this->pl->formData[strtolower($this->player->getName())]["error"])){
+			$error = $this->pl->formData[strtolower($this->player->getName())]["error"];
+		}else{
 			return;
 		}
-			$title = $this->pl->language->getTranslation("error-title");
-			$this->data = [
-				"type" => "modal",
-				"title" => $title,
-				"content" => $error,
-				"button1" => "Go Back",
-				"button2" => "Exit"
-			];
-		}
-		
+		$title = $this->pl->language->getTranslation("error-title");
+		$this->data = [
+			"type"    => "modal",
+			"title"   => $title,
+			"content" => $error,
+			"button1" => "Go Back",
+			"button2" => "Exit",
+		];
+	}
+
+	public function handle(ModalFormResponsePacket $packet): bool{
+		$index = $packet->formData;
+		$this->select($index);
+
+		return true;
+	}
+
 	private function select($index){
 		$windowHandler = new Handler();
 		switch($index){
 			case "true\n":
-			$this->navigate(Handler::KIT_MAIN_MENU, $this->player, $windowHandler);
-			break;
+				$this->navigate(Handler::KIT_MAIN_MENU, $this->player, $windowHandler);
+				break;
 			case "false\n":
-			break;
+				break;
 		}
-	}
-	public function handle(ModalFormResponsePacket $packet): bool {
-			$index = $packet->formData;
-			$this->select($index);
-			return true;
 	}
 }

--- a/src/Infernus101/KitUI/UI/windows/KitInfo.php
+++ b/src/Infernus101/KitUI/UI/windows/KitInfo.php
@@ -90,8 +90,8 @@ class KitInfo extends Window {
 					$this->navigate(Handler::KIT_ERROR, $this->player, $windowHandler);
 					break;
 				}
-				$kits->add($this->player);
-				$this->player->sendMessage($this->pl->language->getTranslation("selected-kit", $name));
+				/** @noinspection PhpUnhandledExceptionInspection */
+				$kits->equipKit($this->player);
 				break;
 			case "false\n":
 				$this->navigate(Handler::KIT_MAIN_MENU, $this->player, $windowHandler);

--- a/src/Infernus101/KitUI/UI/windows/KitInfo.php
+++ b/src/Infernus101/KitUI/UI/windows/KitInfo.php
@@ -2,99 +2,100 @@
 
 namespace Infernus101\KitUI\UI\windows;
 
-use Infernus101\KitUI\Main;
 use Infernus101\KitUI\UI\Handler;
 use Infernus101\KitUI\UI\Window;
-use pocketmine\utils\TextFormat;
-use pocketmine\network\mcpe\protocol\ModalFormRequestPacket;
-use pocketmine\network\mcpe\protocol\ModalFormResponsePacket;
-use pocketmine\Player;
 use onebone\economyapi\EconomyAPI;
+use pocketmine\network\mcpe\protocol\ModalFormResponsePacket;
 
 class KitInfo extends Window {
-	public function process(): void {
-		$info = "";
-		if(isset($this->pl->id[strtolower($this->player->getName())]["kit"])){
-			$kit = $this->pl->id[strtolower($this->player->getName())]["kit"];
-		}
-		else{
+
+	public function process(): void{
+		if(isset($this->pl->formData[strtolower($this->player->getName())]["kit"])){
+			$kit = $this->pl->formData[strtolower($this->player->getName())]["kit"];
+		}else{
 			return;
 		}
+
+		$info = "";
 		if($kit != null){
 			$kits = $this->pl->getKit($kit);
 			if(isset($kits->data["info"])) $info = $kits->data["info"];
 		}
 		$title = $this->pl->language->getTranslation("select-option");
-			$this->data = [
-				"type" => "modal",
-				"title" => $title,
-				"content" => $info,
-				"button1" => "Yes",
-				"button2" => "No"
-			];
-		}
-		
+		$this->data = [
+			"type"    => "modal",
+			"title"   => $title,
+			"content" => $info,
+			"button1" => "Yes",
+			"button2" => "No",
+		];
+	}
+
+	public function handle(ModalFormResponsePacket $packet): bool{
+		$index = $packet->formData;
+		$this->select($index);
+
+		return true;
+	}
+
 	private function select($index){
 		$windowHandler = new Handler();
 		switch($index){
 			case "true\n":
-			if(isset($this->pl->id[strtolower($this->player->getName())]["kit"])){
-			$kit = $this->pl->id[strtolower($this->player->getName())]["kit"];
-			}
-			if($kit == null){
-				$error = "Wrong Session! Try again!";
-				$this->pl->id[strtolower($this->player->getName())]["error"] = $error;
-				$this->navigate(Handler::KIT_ERROR, $this->player, $windowHandler);
-				break;
-			}
-			$kits = $this->pl->getKit($kit);
-			if($kits != null){
-				$name = $kits->getName();
-			}else{
-				$error = "Kit not found! Try again!";
-				$this->pl->id[strtolower($this->player->getName())]["error"] = $error;
-				$this->navigate(Handler::KIT_ERROR, $this->player, $windowHandler);
-				break;
-			}
-			if(!$kits->testPermission($this->player)){
-				$error = $this->pl->language->getTranslation("noperm", $name);
-				$this->pl->id[strtolower($this->player->getName())]["error"] = $error;
-				$this->navigate(Handler::KIT_ERROR, $this->player, $windowHandler);
-				break;
-			}
-			if(isset($kits->data["money"])){
-				$money = $kits->data["money"];
-				if(EconomyAPI::getInstance()->myMoney($this->player) < $money){
-					$error = $this->pl->language->getTranslation("cant-afford", $name, $money);
-					$this->pl->id[strtolower($this->player->getName())]["error"] = $error;
+				if(isset($this->pl->formData[strtolower($this->player->getName())]["kit"])){
+					$kit = $this->pl->formData[strtolower($this->player->getName())]["kit"];
+				}else{
+					$kit = null;
+				}
+				if($kit == null){
+					$error = "Wrong Session! Try again!";
+					$this->pl->formData[strtolower($this->player->getName())]["error"] = $error;
 					$this->navigate(Handler::KIT_ERROR, $this->player, $windowHandler);
 					break;
 				}
-			}
-			if(isset($kits->timers[strtolower($this->player->getName())]) and !$this->player->hasPermission("kit.freepass")){
-				$left = $kits->getTimerLeft($this->player);
-				$error = $this->pl->language->getTranslation("timer1", $name) . "\n" . $this->pl->language->getTranslation("timer2", $left);
-				$this->pl->id[strtolower($this->player->getName())]["error"] = $error;
-				$this->navigate(Handler::KIT_ERROR, $this->player, $windowHandler);
+				$kits = $this->pl->getKit($kit);
+				if($kits != null){
+					$name = $kits->getName();
+				}else{
+					$error = "Kit not found! Try again!";
+					$this->pl->formData[strtolower($this->player->getName())]["error"] = $error;
+					$this->navigate(Handler::KIT_ERROR, $this->player, $windowHandler);
+					break;
+				}
+				if(!$kits->testPermission($this->player)){
+					$error = $this->pl->language->getTranslation("noperm", $name);
+					$this->pl->formData[strtolower($this->player->getName())]["error"] = $error;
+					$this->navigate(Handler::KIT_ERROR, $this->player, $windowHandler);
+					break;
+				}
+				if(isset($kits->data["money"])){
+					$money = $kits->data["money"];
+					if(EconomyAPI::getInstance()->myMoney($this->player) < $money){
+						$error = $this->pl->language->getTranslation("cant-afford", $name, $money);
+						$this->pl->formData[strtolower($this->player->getName())]["error"] = $error;
+						$this->navigate(Handler::KIT_ERROR, $this->player, $windowHandler);
+						break;
+					}
+				}
+				if(isset($kits->timers[strtolower($this->player->getName())]) and !$this->player->hasPermission("kit.freepass")){
+					$left = $kits->getTimerLeft($this->player);
+					$error = $this->pl->language->getTranslation("timer1", $name) . "\n" . $this->pl->language->getTranslation("timer2", $left);
+					$this->pl->formData[strtolower($this->player->getName())]["error"] = $error;
+					$this->navigate(Handler::KIT_ERROR, $this->player, $windowHandler);
+					break;
+				}
+				if(($this->pl->config->get("one-kit-per-life")) and (isset($kits->pl->kitUsed[strtolower($this->player->getName())])) and !$this->player->hasPermission("kit.freepass." . strtolower($name))){
+					$error = $this->pl->language->getTranslation("one-per-life");
+					$this->pl->formData[strtolower($this->player->getName())]["error"] = $error;
+					$this->navigate(Handler::KIT_ERROR, $this->player, $windowHandler);
+					break;
+				}
+				$kits->add($this->player);
+				$this->player->sendMessage($this->pl->language->getTranslation("selected-kit", $name));
 				break;
-			}
-			if(($this->pl->config->get("one-kit-per-life")) and (isset($kits->pl->kitused[strtolower($this->player->getName())])) and !$this->player->hasPermission("kit.freepass.".strtolower($name))){
-				$error = $this->pl->language->getTranslation("one-per-life");
-				$this->pl->id[strtolower($this->player->getName())]["error"] = $error;
-				$this->navigate(Handler::KIT_ERROR, $this->player, $windowHandler);
-				break;
-			}
-			$kits->add($this->player);
-			$this->player->sendMessage($this->pl->language->getTranslation("selected-kit", $name));
-			break;
 			case "false\n":
-			$this->navigate(Handler::KIT_MAIN_MENU, $this->player, $windowHandler);
-			break;
+				$this->navigate(Handler::KIT_MAIN_MENU, $this->player, $windowHandler);
+				break;
 		}
-	}
-	public function handle(ModalFormResponsePacket $packet): bool {
-			$index = $packet->formData;
-			$this->select($index);
-			return true;
 	}
 }

--- a/src/Infernus101/KitUI/UI/windows/KitMainMenu.php
+++ b/src/Infernus101/KitUI/UI/windows/KitMainMenu.php
@@ -2,48 +2,44 @@
 
 namespace Infernus101\KitUI\UI\windows;
 
-use Infernus101\KitUI\Main;
 use Infernus101\KitUI\UI\Handler;
 use Infernus101\KitUI\UI\Window;
-use pocketmine\utils\TextFormat;
-use pocketmine\network\mcpe\protocol\ModalFormRequestPacket;
 use pocketmine\network\mcpe\protocol\ModalFormResponsePacket;
-use pocketmine\Player;
 
 class KitMainMenu extends Window {
-	public function process(): void {
-		$url = "";
-		parent::$id = array();
+	public function process(): void{
+		parent::$id = [];
 		$title = $this->pl->language->getTranslation("mainmenu-title");
 		$content = $this->pl->language->getTranslation("mainmenu-content");
 		$this->data = [
-			"type" => "form",
-			"title" => $title,
+			"type"    => "form",
+			"title"   => $title,
 			"content" => $content,
-			"buttons" => []
+			"buttons" => [],
 		];
 		foreach($this->pl->kits as $name => $data){
 			$name = ucfirst($name);
 			$name2 = $name;
 			$kits = $this->pl->getKit($name);
-			if(isset($kits->data["kit-name"]))	
+			if(isset($kits->data["kit-name"]))
 				$name2 = $kits->data["kit-name"];
 			if(isset($kits->data["image-url"])){
-			$url = $kits->data["image-url"];
-			$this->data["buttons"][] = ["text" => "$name2", "image" => ["type" => "url", "data" => $url]];
+				$url = $kits->data["image-url"];
+				$this->data["buttons"][] = ["text" => "$name2", "image" => ["type" => "url", "data" => $url]];
 			}else{
-			$this->data["buttons"][] = ["text" => "$name2"];	
+				$this->data["buttons"][] = ["text" => "$name2"];
 			}
 			array_push(parent::$id, "$name");
 		}
 	}
 
-	public function handle(ModalFormResponsePacket $packet): bool {
-		$index = (int) $packet->formData;
+	public function handle(ModalFormResponsePacket $packet): bool{
+		$index = (int)$packet->formData;
 		$windowHandler = new Handler();
-		if(isset(parent::$id[$index])) $this->pl->id[strtolower($this->player->getName())]["kit"] = parent::$id[$index];
-		else $this->pl->id[strtolower($this->player->getName())]["kit"] = null;
+		if(isset(parent::$id[$index])) $this->pl->formData[strtolower($this->player->getName())]["kit"] = parent::$id[$index];
+		else $this->pl->formData[strtolower($this->player->getName())]["kit"] = null;
 		$this->navigate(Handler::KIT_INFO, $this->player, $windowHandler);
+
 		return true;
 	}
 }

--- a/src/Infernus101/KitUI/events/KitEquipEvent.php
+++ b/src/Infernus101/KitUI/events/KitEquipEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Infernus101\KitUI\events;
+
+use Infernus101\KitUI\Kit;
+use pocketmine\event\Cancellable;
+use pocketmine\Player;
+
+/**
+ * This event is called when the player is trying to
+ * equip a kit that has been purchased.
+ *
+ * @package Infernus101\KitUI\events
+ * @author larryTheCoder
+ */
+class KitEquipEvent extends KitEvent implements Cancellable {
+
+	/** @var Player */
+	private $player;
+
+	/**
+	 * @param Player $p
+	 * @param Kit $kit
+	 */
+	public function __construct(Player $p, Kit $kit){
+		parent::__construct($kit);
+
+		$this->player = $p;
+	}
+
+	/**
+	 * Get the player that equips this kit.
+	 *
+	 * @return Player
+	 */
+	public function getPlayer(): Player{
+		return $this->player;
+	}
+}

--- a/src/Infernus101/KitUI/events/KitEvent.php
+++ b/src/Infernus101/KitUI/events/KitEvent.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Infernus101\KitUI\events;
+
+use Infernus101\KitUI\Kit;
+use pocketmine\event\Event;
+
+/**
+ * The backbone of the kit event itself
+ *
+ * @package Infernus101\KitUI\events
+ * @author larryTheCoder
+ */
+abstract class KitEvent extends Event {
+
+	/** @var Kit */
+	private $kit;
+
+	public function __construct(Kit $kit){
+		$this->kit = $kit;
+	}
+
+	/**
+	 * Get the kit that is being used.
+	 *
+	 * @return Kit
+	 */
+	public function getKit(){
+		return $this->kit;
+	}
+}

--- a/src/Infernus101/KitUI/events/KitPurchaseEvent.php
+++ b/src/Infernus101/KitUI/events/KitPurchaseEvent.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Infernus101\KitUI\events;
+
+use Infernus101\KitUI\Kit;
+use pocketmine\event\Cancellable;
+use pocketmine\Player;
+
+/**
+ * This event is called when there is a purchase from
+ * the player itself.
+ *
+ * @package Infernus101\KitUI\events
+ * @author larryTheCoder
+ */
+class KitPurchaseEvent extends KitEvent implements Cancellable {
+
+	/** @var int */
+	private $price;
+	/** @var Player */
+	private $player;
+
+	/**
+	 * KitPurchaseEvent constructor.
+	 *
+	 * @param Player $pl
+	 * @param Kit $kit
+	 * @param int $price
+	 */
+	public function __construct(Player $pl, Kit $kit, int $price){
+		parent::__construct($kit);
+
+		$this->player = $pl;
+		$this->price = $price;
+	}
+
+	/**
+	 * Get the player that purchased this
+	 * kit.
+	 *
+	 * @return Player
+	 */
+	public function getPlayer(): Player{
+		return $this->player;
+	}
+
+	/**
+	 * Get the amount of money that is required to
+	 * purchase this kit.
+	 *
+	 * @return int
+	 */
+	public function getPrice(): int{
+		return $this->price;
+	}
+
+	/**
+	 * Set the price of the kit.
+	 *
+	 * @param int $price
+	 */
+	public function setPrice(int $price){
+		$this->price = $price;
+	}
+}

--- a/src/Infernus101/KitUI/lang/LangManager.php
+++ b/src/Infernus101/KitUI/lang/LangManager.php
@@ -5,52 +5,54 @@ namespace Infernus101\KitUI\lang;
 use Infernus101\KitUI\Main;
 use pocketmine\utils\Config;
 
-class LangManager{
+class LangManager {
 
-    const LANG_VERSION = 0;
+	const LANG_VERSION = 0;
 
-    private $pl;
-    private $defaults;
-    private $data;
+	private $pl;
+	private $defaults;
+	private $data;
 
-    public function __construct(Main $pl){
-        $this->pl = $pl;
-        $this->defaults = [
-            "lang-version" => 0,
-			"error-title" => "Error:",
-			"mainmenu-title" => "Kits -",
+	public function __construct(Main $pl){
+		$this->pl = $pl;
+		$this->defaults = [
+			"lang-version"     => 0,
+			"error-title"      => "Error:",
+			"mainmenu-title"   => "Kits -",
 			"mainmenu-content" => "Select a kit for info -",
-			"select-option" => "Do you wanna select this kit, player?",
-            "selected-kit" => "Selected kit: {%0}",
-            "inv-full" => "You do not have enough space in your inventory for this kit",
-            "cant-afford" => "You cannot afford kit: {%0} Cost: {%1}",
-            "one-per-life" => "You can only get one kit per life",
-            "no-sign-perm" => "You don't have permission to create kit sign",
-            "timer1" => "Kit {%0} is in cooldown at the moment",
-            "timer2" => "You will be able to get it in {%0}",
-            "noperm" => "You don't have the permission to use kit {%0}",
-            "timer-format1" => "{%0} minutes",
-            "timer-format2" => "{%0} hours and {%1} minutes",
-            "timer-format3" => "{%0} hours",
-        ];
-        $this->data = new Config($this->pl->getDataFolder()."lang.properties", Config::PROPERTIES, $this->defaults);
-        if($this->data->get("lang-version") != self::LANG_VERSION){
-            $this->pl->getLogger()->alert("Translation file is outdated. The old file has been renamed and a new one has been created");
-            @rename($this->pl->getDataFolder()."lang.properties", $this->pl->getDataFolder()."lang.properties.old");
-            $this->data = new Config($this->pl->getDataFolder()."lang.properties", Config::PROPERTIES, $this->defaults);
-        }
-    }
+			"select-option"    => "Do you wanna select this kit, player?",
+			"selected-kit"     => "Selected kit: {%0}",
+			"inv-full"         => "You do not have enough space in your inventory for this kit",
+			"cant-afford"      => "You cannot afford kit: {%0} Cost: {%1}",
+			"one-per-life"     => "You can only get one kit per life",
+			"no-sign-perm"     => "You don't have permission to create kit sign",
+			"timer1"           => "Kit {%0} is in cooldown at the moment",
+			"timer2"           => "You will be able to get it in {%0}",
+			"noperm"           => "You don't have the permission to use kit {%0}",
+			"timer-format1"    => "{%0} minutes",
+			"timer-format2"    => "{%0} hours and {%1} minutes",
+			"timer-format3"    => "{%0} hours",
+		];
+		$this->data = new Config($this->pl->getDataFolder() . "lang.properties", Config::PROPERTIES, $this->defaults);
+		if($this->data->get("lang-version") != self::LANG_VERSION){
+			$this->pl->getLogger()->alert("Translation file is outdated. The old file has been renamed and a new one has been created");
+			@rename($this->pl->getDataFolder() . "lang.properties", $this->pl->getDataFolder() . "lang.properties.old");
+			$this->data = new Config($this->pl->getDataFolder() . "lang.properties", Config::PROPERTIES, $this->defaults);
+		}
+	}
 
-    public function getTranslation(string $dataKey, ...$args) : string{
-        if(!isset($this->defaults[$dataKey])){
-            $this->pl->getLogger()->error("Invalid datakey $dataKey passed to method LangManager::getTranslation()");
-            return "";
-        }
-        $str = $this->data->get($dataKey, $this->defaults[$dataKey]);
-        foreach($args as $key => $arg){
-            $str = str_replace("{%".$key."}", $arg, $str);
-        }
-        return $str;
-    }
+	public function getTranslation(string $dataKey, ...$args): string{
+		if(!isset($this->defaults[$dataKey])){
+			$this->pl->getLogger()->error("Invalid datakey $dataKey passed to method LangManager::getTranslation()");
+
+			return "";
+		}
+		$str = $this->data->get($dataKey, $this->defaults[$dataKey]);
+		foreach($args as $key => $arg){
+			$str = str_replace("{%" . $key . "}", $arg, $str);
+		}
+
+		return $str;
+	}
 
 }

--- a/src/Infernus101/KitUI/tasks/CoolDownTask.php
+++ b/src/Infernus101/KitUI/tasks/CoolDownTask.php
@@ -5,18 +5,18 @@ namespace Infernus101\KitUI\tasks;
 use Infernus101\KitUI\Main;
 use pocketmine\scheduler\Task;
 
-class CoolDownTask extends Task{
+class CoolDownTask extends Task {
 
-    private $plugin;
+	private $plugin;
 
-    public function __construct(Main $plugin){
-        $this->plugin = $plugin;
-    }
+	public function __construct(Main $plugin){
+		$this->plugin = $plugin;
+	}
 
-    public function onRun(int $tick){
-        foreach($this->plugin->kits as $kit){
-            $kit->processTimer();
-        }
-    }
+	public function onRun(int $tick){
+		foreach($this->plugin->kits as $kit){
+			$kit->processTimer();
+		}
+	}
 
 }


### PR DESCRIPTION
<!-- Congrats, you just found this, I need this pull request to be pushed so I could use it in my SkyWars plugin, there is people wanting it and I see that this plugin doesn't have enough functions to be manipulated -->

# Pull Request description
Since this plugin only intended for "server use" and not "plugin use", I decided to add some events on this plugin so developers could actually cancels, change or listen to any changes that has been made in this plugin or player itself. 

### Name of events
- `KitEvent` Backbone of the kit event and not intended to be used, but extends to it. 
- `KitEquipEvent`  This event is called when the player tries to equip a kit without paying it first.
- `KitPurchaseEvent` This event will be called if there is a price when buying a kit.

_You could add another event if you want to, this is just basics for the kit events, as some additional requests to use this kit on their plugins_

<!-- OPTIONAL INFORMATION - use this section for posting crash dumps, backtraces or other files(please use code markdown!) -->
## Code of the API
```php
// This is a function in a class that implements listener and
// Has been registered by event Listener.

// use Infernus101\KitUI\events\KitPurchaseEvent;
public function onKitPurchase(KitPurchaseEvent $event){
	$event->setPrice(500);       // Set the amount that you want.

	$pl = $event->getPlayer();   // Get the player that buys the kit.
	$price = $event->getPrice(); // The price of the kit.

	// This message will be sent to the player.
	$pl->sendMessage("You bought this kit for $price");
}

// use Infernus101\KitUI\events\KitEquipEvent;
public function onKitEquip(KitEquipEvent $event){
	$pl = $event->getPlayer();   // Get the player that buys the kit.
	$kit = $event->getKit();     // Return the kit that player tries to equip

	$event->setCancelled(true);  // Cancels them
}
```

### Side note
This code has been formatted properly and documented as possible.
